### PR TITLE
Close DB session before exiting method

### DIFF
--- a/tutorial/pipelines.py
+++ b/tutorial/pipelines.py
@@ -26,12 +26,11 @@ class DuplicatesPipeline(object):
     def process_item(self, item, spider):
         session = self.Session()
         exist_quote = session.query(Quote).filter_by(quote_content = item["quote_content"]).first()
+        session.close()
         if exist_quote is not None:  # the current quote exists
             raise DropItem("Duplicate item found: %s" % item["quote_content"])
-            session.close()
         else:
             return item
-            session.close()
 
 
 class SaveQuotesPipeline(object):


### PR DESCRIPTION
Prevents abandoned database connections when running `process_item`.

Tested manually by running `scrapy crawl quotes` twice. Only 50 rows present in the `quote` table after each run.